### PR TITLE
Increase threshold for NMS

### DIFF
--- a/test.py
+++ b/test.py
@@ -22,7 +22,7 @@ parser.add_argument('--cpu', action="store_true", default=False, help='Use cpu i
 parser.add_argument('--dataset', default='PASCAL', type=str, choices=['AFW', 'PASCAL', 'FDDB'], help='dataset')
 parser.add_argument('--confidence_threshold', default=0.05, type=float, help='confidence_threshold')
 parser.add_argument('--top_k', default=5000, type=int, help='top_k')
-parser.add_argument('--nms_threshold', default=0.3, type=float, help='nms_threshold')
+parser.add_argument('--nms_threshold', default=0.6, type=float, help='nms_threshold')
 parser.add_argument('--keep_top_k', default=750, type=int, help='keep_top_k')
 args = parser.parse_args()
 


### PR DESCRIPTION
The threshold given to NMS (0.3) is far too low and includes many false positives. If someone wanted to see them, they can set the value themselves but I think the default should be slightly more sane. I personally use 0.7 or 0.8.

This also improves some benchmarks. Compared to my last patch:
PASCAL: 97.28% -> 97.28% (unchanged)
AFW: 98.83% -> 99.01% (would be 99.04% with 0.7)