### PR TITLE
Increase detection y offset

### DIFF
--- a/test.py
+++ b/test.py
@@ -165,7 +165,7 @@ if __name__ == '__main__':
                 ymin = dets[k, 1]
                 xmax = dets[k, 2]
                 ymax = dets[k, 3]
-                ymin += 0.2 * (ymax - ymin + 1)
+                ymin += 0.3 * (ymax - ymin + 1)
                 score = dets[k, 4]
                 fw.write('{:s} {:.3f} {:.1f} {:.1f} {:.1f} {:.1f}\n'.format(img_name, score, xmin, ymin, xmax, ymax))
         print('im_detect: {:d}/{:d} forward_pass_time: {:.4f}s misc: {:.4f}s'.format(i + 1, num_images, _t['forward_pass'].average_time, _t['misc'].average_time))


### PR DESCRIPTION
Tests are expecting the offset to be centred around a different part of the face as face is segmented in to thirds (eye -> mouth).
Correct this value to 0.3.

Changes benchmarks as compared to previous patch:
PASCAL: 97.28% -> 97.33%
AFW: 99.01% -> 99.01% (unchanged)